### PR TITLE
Add Web3 Trackers — on-chain marketing attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 | Momentum Radar          | ![Momentum Radar](https://github.com/user-attachments/assets/8ed83743-d342-451f-a734-a38a0d70fce1)                   | [momentumradar.com](https://momentumradar.com/)                               | [Contact](https://momentumradar.com/contact-us/)     | Tactical & Strategic Blueprint For Financial Markets |
 | Holder.io          | ![Holder.io](https://github.com/user-attachments/assets/dfec5e5a-2795-4e01-a6fe-5d5dc857db19)                   | [holder.io](https://holder.io/)                               | [Twitter](https://x.com/Holder_io)     | A platform for tracking cryptocurrencies, tokens, and exchanges with analytical tools. |
 | Bitculator.com | ![bitculator.com](https://bitculator.com/media/do-not-delete/Preview-Dark.png) | [bitculator.com](https://bitculator.com/) | [Twitter](https://x.com/bitculator) | Bitculator is a modern & user-friendly crypto tool designed for both novice and experienced users, we offer live cryptocurrency data, easy-to-use tools, customizable alarms, detailed charts, and interactive lists |
+| Web3 Trackers | ![Web3 Trackers](https://www.web3trackers.com/logo-square.png) | [web3trackers.com](https://www.web3trackers.com/) | [Twitter](https://x.com/web3trackerscom) | On-chain marketing attribution for crypto teams. Tracks which campaigns drive wallet conversions across Ethereum, Base, Solana, and TON. Free tier, no SDK. |
 
 <!-- === ⭐RESEARCH TOOLS END ⭐ === -->
 


### PR DESCRIPTION
Adding Web3 Trackers to the curated list.

**Tool:** Web3 Trackers (https://www.web3trackers.com/)
**Category fit:** Crypto research / analytics — on-chain marketing attribution tool used by DeFi and web3 teams to track which marketing campaigns drive wallet conversions.

**Why it fits this list:**
- Free tier available, no SDK required
- Multi-chain support: Ethereum, Base, Solana, TON
- Public pricing, no demo gate
- Used for measuring crypto marketing ROI on-chain

**Open-source data:** We also publish our category research (pricing comparison + feature matrix for 8 web3 attribution tools) at https://github.com/aerobean/web3-attribution-data under CC-BY-4.0.

Followed the existing table format. Feature image hosted at https://www.web3trackers.com/logo-square.png (PNG, 1:1 aspect).